### PR TITLE
Preserve color output for child commands

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,13 +21,8 @@ const childProcess = execa(
   // @ts-ignore args[0] cannot be undefined here due to the prior check
   args.shift(),
   args,
+  { stdio: ['inherit', 'inherit', 'inherit'] },
 );
-if (childProcess.stdout) {
-  childProcess.stdout.pipe(process.stdout);
-}
-if (childProcess.stderr) {
-  childProcess.stderr.pipe(process.stderr);
-}
 childProcess.catch(() => {
   // noop for a non-zero exit code is the whole purpose of this library
 });

--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ const childProcess = execa(
   // @ts-ignore args[0] cannot be undefined here due to the prior check
   args.shift(),
   args,
-  { stdio: ['inherit', 'inherit', 'inherit'] },
+  { stdio: "inherit" },
 );
 childProcess.catch(() => {
   // noop for a non-zero exit code is the whole purpose of this library


### PR DESCRIPTION
`inherit` makes the most sense for wrapping a command anyway, but specifically, it keeps the pipes associated with a TTY which is necessary for most commands to output colored text via ANSI escape codes.