### PR TITLE
Support pnpm

### DIFF
--- a/main.js
+++ b/main.js
@@ -10,7 +10,9 @@ while (args.length) {
   const arg = /** @type {string} */ (args.shift());
   if (
     arg.includes(".bin") ||
-    arg.includes("suppress-exit-code") ||
+    arg.endsWith("suppress-exit-code") ||
+    arg.endsWith("suppress-exit-code/main.js") ||
+    arg.endsWith("suppress-exit-code\\main.js") ||
     arg === filePath
   ) {
     break;

--- a/main.js
+++ b/main.js
@@ -10,7 +10,7 @@ while (args.length) {
   const arg = /** @type {string} */ (args.shift());
   if (
     arg.includes(".bin") ||
-    arg.endsWith("suppress-exit-code") ||
+    arg.includes("suppress-exit-code") ||
     arg === filePath
   ) {
     break;


### PR DESCRIPTION
Threw an error `Please specify a child command to run` even with a child command in pnpm and Windows.

Command:
```
pnpm suppress-exit-code composer phpcbf .
```

This is because `filePath` defers with the path in `args` as below.

https://github.com/kachkaev/suppress-exit-code/blob/e67e8ba632dc6000616fb1862c04012019f29088/main.js#L6-L22

```js
filePath: C:\Users\name\Documents\GitHub\repo\node_modules\.pnpm\suppress-exit-code@3.1.0\node_modules\suppress-exit-code\main.js
args: [
  'C:\\Program Files\\nodejs\\node.exe',
  'C:\\Users\\name\\Documents\\GitHub\\repo\\node_modules\\suppress-exit-code\\main.js',
  'composer',
  'phpcbf',
  '.'
]
```

This PR fixes the issue by changing `endsWith` to `includes`. I think it might work unless if `node` is in `suppress-exit-code` directory.

However, [meow](https://github.com/sindresorhus/meow/tree/main), the library for CLI, just takes from the second to the last of `process.argv` as args. So, it might be another solution to do like so.

https://github.com/sindresorhus/meow/blob/58eedf48e594b112ac8b3bf14dff1ccd6e0b38c9/source/options.js#L73
